### PR TITLE
Auto convert numeric types when decoding

### DIFF
--- a/assembly/__tests__/numeric_conversion.spec.ts
+++ b/assembly/__tests__/numeric_conversion.spec.ts
@@ -1,0 +1,122 @@
+import { Decoder, Writer, Encoder, Sizer } from "..";
+
+class Wrapper<T> {
+  constructor(public value: T) {}
+
+  fromBuffer(buffer: ArrayBuffer): void {
+    const decoder = new Decoder(buffer);
+    this.decode(decoder);
+  }
+
+  toBuffer(): ArrayBuffer {
+    const sizer = new Sizer();
+    this.encode(sizer);
+    const buffer = new ArrayBuffer(sizer.length);
+    const encoder = new Encoder(buffer);
+    this.encode(encoder);
+    return buffer;
+  }
+
+  decode(reader: Decoder): void {
+    var numFields = reader.readMapSize();
+
+    while (numFields > 0) {
+      numFields--;
+      const field = reader.readString();
+
+      if (field == "value") {
+        if (this.value instanceof u8) {
+          this.value = <T>reader.readUInt8();
+        } else if (this.value instanceof u16) {
+          this.value = <T>reader.readUInt16();
+        } else if (this.value instanceof i32) {
+          this.value = <T>reader.readInt32();
+        } else if (this.value instanceof f32) {
+          this.value = <T>reader.readFloat32();
+        } else if (this.value instanceof f64) {
+          this.value = <T>reader.readFloat64();
+        } else {
+          throw new Error("not implemented");
+        }
+      } else {
+        reader.skip();
+      }
+    }
+  }
+
+  encode(writer: Writer): void {
+    writer.writeMapSize(1);
+    writer.writeString("value");
+    if (this.value instanceof u8) {
+      writer.writeUInt8(<u8>this.value);
+    } else if (this.value instanceof u16) {
+      writer.writeUInt16(<u16>this.value);
+    } else if (this.value instanceof i32) {
+      writer.writeInt32(<i32>this.value);
+    } else if (this.value instanceof f32) {
+      writer.writeFloat32(<f32>this.value);
+    } else if (this.value instanceof f64) {
+      writer.writeFloat64(<f64>this.value);
+    } else {
+      throw new Error("not implemented");
+    }
+  }
+}
+
+describe("CodecNumericConversionCheck", () => {
+  describe("integer", () => {
+    it("auto converts for compatible value from u8 to i32", () => {
+      const input = new Wrapper<u8>(128);
+      const output = new Wrapper<i32>(0);
+      output.fromBuffer(input.toBuffer());
+      expect(output.value).toStrictEqual(128);
+    });
+
+    it("auto converts for compatible value from i32 to u16", () => {
+      const input = new Wrapper<i32>(128);
+      const output = new Wrapper<u16>(0);
+      output.fromBuffer(input.toBuffer());
+      expect(output.value).toStrictEqual(128);
+    });
+
+    it("throws an error for underflow value", () => {
+      expect(() => {
+        const input = new Wrapper<i32>(-42);
+        const output = new Wrapper<u8>(0);
+        output.fromBuffer(input.toBuffer())
+      }).toThrow();
+    });
+
+    it("throws an error for overflow value", () => {
+      expect(() => {
+        const input = new Wrapper<u16>(257);
+        const output = new Wrapper<u8>(0);
+        output.fromBuffer(input.toBuffer())
+      }).toThrow();
+    });
+  });
+
+  describe("float", () => {
+    it("auto converts compatible value from f32 to f64", () => {
+      const input = new Wrapper<f32>(1.0);
+      const output = new Wrapper<f64>(0.0);
+      output.fromBuffer(input.toBuffer());
+      expect(output.value).toStrictEqual(1.0);
+    });
+
+    it("auto converts compatible value from f64 to f32", () => {
+      const input = new Wrapper<f64>(1.0);
+      const output = new Wrapper<f32>(0.0);
+      output.fromBuffer(input.toBuffer());
+      expect(output.value).toStrictEqual(1.0);
+    });
+
+    it("throws an error for overflow value", () => {
+      expect(() => {
+        const input = new Wrapper<f64>(f64.MAX_VALUE);
+        const output = new Wrapper<f32>(0.0);
+        output.fromBuffer(input.toBuffer())
+      }).toThrow();
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,69 +1,69 @@
 {
   "name": "@wapc/as-msgpack",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@as-pect/assembly": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@as-pect/assembly/-/assembly-4.0.0.tgz",
-      "integrity": "sha512-xkyyWlpOnD7n01bJQivKAePAvg7D4eygp72BgzRfvZxTTTtGDfLU1jwB5gZr8XX5bFkpF/+W5lk/Uqt5LLchWA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@as-pect/assembly/-/assembly-6.0.0.tgz",
+      "integrity": "sha512-B1bBMg2onl+RomWLlsWfrHdB8d4Xu7GOJn5eMwI4gjXvDKfbNXeSrL1gdkL7oZAHCf04XJ0XRWdUXfPdqTZdGA==",
       "dev": true
     },
     "@as-pect/cli": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@as-pect/cli/-/cli-4.0.0.tgz",
-      "integrity": "sha512-OT0iFPmSzmygrLm4lpDgUgbG3KVdE2XoatbNKav0VM7yIIXozc3vwUeDgEwB9NBxnZC/pnp0pZmpM4rXi5IUpw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@as-pect/cli/-/cli-6.0.0.tgz",
+      "integrity": "sha512-YlRP56oflSwal03VXG/e08Ov8RsTvSYRajXh8Bb3HTLJaaoQhoodgHkQJPTZQy1rhIvJvYRN1uqZkZdppB8M/A==",
       "dev": true,
       "requires": {
-        "@as-pect/assembly": "^4.0.0",
-        "@as-pect/core": "^4.0.0",
-        "@as-pect/csv-reporter": "^4.0.0",
-        "@as-pect/json-reporter": "^4.0.0",
+        "@as-pect/assembly": "^6.0.0",
+        "@as-pect/core": "^6.0.0",
+        "@as-pect/csv-reporter": "^6.0.0",
+        "@as-pect/json-reporter": "^6.0.0",
         "chalk": "^4.1.0",
         "glob": "^7.1.6"
       }
     },
     "@as-pect/core": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@as-pect/core/-/core-4.0.0.tgz",
-      "integrity": "sha512-NQhf52uumBuQkqSvfmlMDHPhP/jR+2kkXt5BWQ0LnifWyBIsP4GUIe43VjW5brou2WVk+bDxlyo7lEtqideOKA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@as-pect/core/-/core-6.0.0.tgz",
+      "integrity": "sha512-48KVLSZvUbIk0tjhwE6AIrnPICdWoziex0fmmvoXHHnNOoXv5lZPYwS/CjZcl8SAQlIgj6Qe692yo85BfCxE9g==",
       "dev": true,
       "requires": {
-        "@as-pect/assembly": "^4.0.0",
-        "@as-pect/snapshots": "^4.0.0",
+        "@as-pect/assembly": "^6.0.0",
+        "@as-pect/snapshots": "^6.0.0",
         "chalk": "^4.1.0",
         "long": "^4.0.0"
       }
     },
     "@as-pect/csv-reporter": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@as-pect/csv-reporter/-/csv-reporter-4.0.0.tgz",
-      "integrity": "sha512-5M4btRHhUZtcdIf4jeaRzwG0+OgTGvIWoUsNyedeuV5HDIjRM8kb9k+IKjfZqD3dU8TD/C2Ca7Gr4zkbAlswkw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@as-pect/csv-reporter/-/csv-reporter-6.0.0.tgz",
+      "integrity": "sha512-2SrSN0UstjUlFCW7L/Z33tufTfWDOwPAZZ8WJNiiWbOgPSh0ML899DabR8UbH7eVQe1aeyS2LCSjhVKtmb7uSg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@as-pect/core": "^4.0.0"
+        "@as-pect/core": "^6.0.0"
       }
     },
     "@as-pect/json-reporter": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@as-pect/json-reporter/-/json-reporter-4.0.0.tgz",
-      "integrity": "sha512-1ekBZlAXOqeN6f5abwBtMiRaH6/6UciepArC7O0wkuI+3nAoj6XUSkRonl8kb/j7zmYbjlsD5UqTNILL+kl+Tg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@as-pect/json-reporter/-/json-reporter-6.0.0.tgz",
+      "integrity": "sha512-MW+bocR8Ys859oZwMighOY5ZWv0MDUGs1FToLwXOXk93EzlOyToDZ2ntEODpZW2zU8xX5rLv6zU/n1yr263i1g==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@as-pect/core": "^4.0.0"
+        "@as-pect/core": "^6.0.0"
       }
     },
     "@as-pect/snapshots": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@as-pect/snapshots/-/snapshots-4.0.0.tgz",
-      "integrity": "sha512-RBSGTVyBdbpabj/FTp8k3XUTnCSeutmLVgfjVbzzLLZVeNV2i7sVp5acau//qq884ZnXv/gd/g9fleHPYtBxkQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@as-pect/snapshots/-/snapshots-6.0.0.tgz",
+      "integrity": "sha512-5OMKJWYm3cfEX28TroY9j5CIhwO6q/300GShrxpDaNYva/HgA8iPY4dGdbiI4xcCf8xaHuBq2HQi0kYS+1wqjQ==",
       "dev": true,
       "requires": {
-        "diff": "^4.0.2",
-        "nearley": "^2.19.3"
+        "diff": "^5.0.0",
+        "nearley": "^2.20.1"
       }
     },
     "ansi-styles": {
@@ -76,12 +76,12 @@
       }
     },
     "assemblyscript": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.16.1.tgz",
-      "integrity": "sha512-btb/Q2cs42O7NaVRLDpUIb4fF+o4H4id0kjOOOzS25KCOx0voiyGBeWYqfnrOeufMQacvDNqGkjJuGkdTJIrQQ==",
+      "version": "0.18.11",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.18.11.tgz",
+      "integrity": "sha512-QIIPeHRq+0uw7A2xWzmJM1I8Ca7AGuNpp2JFFkdTBMfVrQULtWieqOBIZG+VDRbYEbjbCdonEWcnGCi2ujzz6Q==",
       "dev": true,
       "requires": {
-        "binaryen": "97.0.0-nightly.20201008",
+        "binaryen": "98.0.0-nightly.20210106",
         "long": "^4.0.0"
       }
     },
@@ -92,9 +92,9 @@
       "dev": true
     },
     "binaryen": {
-      "version": "97.0.0-nightly.20201008",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-97.0.0-nightly.20201008.tgz",
-      "integrity": "sha512-GWV30FOQqz+vBIZRbc7GSasLNhh8BNLKH+2u2j5BjqM0WOEqqaP5iSj0mq72We2aVYqpBajJPI/CORY6o2RBxA==",
+      "version": "98.0.0-nightly.20210106",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-98.0.0-nightly.20210106.tgz",
+      "integrity": "sha512-iunAgesqT9PXVYCc72FA4h0sCCKLifruT6NuUH63xqlFJGpChhZLgOtyIb/fIgTibN5Pd692cxfBViyCWFsJ9Q==",
       "dev": true
     },
     "brace-expansion": {
@@ -145,9 +145,9 @@
       "dev": true
     },
     "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true
     },
     "discontinuous-range": {
@@ -220,16 +220,15 @@
       "dev": true
     },
     "nearley": {
-      "version": "2.19.7",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.7.tgz",
-      "integrity": "sha512-Y+KNwhBPcSJKeyQCFjn8B/MIe+DDlhaaDgjVldhy5xtFewIbiQgcbZV8k2gCVwkI1ZsKCnjIYZbR+0Fim5QYgg==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
       "dev": true,
       "requires": {
         "commander": "^2.19.0",
         "moo": "^0.5.0",
         "railroad-diagrams": "^1.0.0",
-        "randexp": "0.4.6",
-        "semver": "^5.4.1"
+        "randexp": "0.4.6"
       }
     },
     "once": {
@@ -267,12 +266,6 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-      "dev": true
-    },
-    "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "homepage": "https://github.com/wapc/as-msgpack#readme",
   "devDependencies": {
-    "@as-pect/cli": "4.0.0",
-    "assemblyscript": "^0.17.1"
+    "@as-pect/cli": "6.0.x",
+    "assemblyscript": "0.18.x"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
👋  Hey guys, thanks for making the as-msgpack package. I'm running into a small issue and I created this PR to propose a fix.

**Context**

In a dynamic type language, which doesn't have proper type annotation
over `i8/i16/i32/i64`, `u8/u16/u32/u64` or `f32/f64`, it encodes a numeric
value simply for what it fits. Or in the case when we transform a numeric
value from JSON to MsgPack, there is no way to specify the exact type
the value is. In these cases, the current decoder fails to parse the value.

For example,

```json
{ "value": 128 }
```

When transforming the JSON value to Msgpack, it becomes

```
[ ..., 204, 128 ]
       ----
         |
         |-> 0xcc which is flag byte for u8
```

If the value is tagged as `i32` in AS code, it fails to properly decode
when using `decoder.readInt32()`, which results in a `bad prefix` error.

**This commit**

This commit updates the decoder to auto converts compatible
values and throws an error on value overflow and underflow.