### PR TITLE
Implement a SafeDecoder

### DIFF
--- a/assembly/__tests__/msgpack.spec.ts
+++ b/assembly/__tests__/msgpack.spec.ts
@@ -1,7 +1,8 @@
-import { Decoder, Writer, Encoder, Sizer } from "..";
+import { SafeDecoder, Decoder, Writer, Encoder, Sizer } from "..";
 
 class CodecTest {
   nil: string | null = "null";
+  bool: bool;
   int8: i8;
   int16: i16;
   int32: i32;
@@ -16,9 +17,12 @@ class CodecTest {
   bytes: ArrayBuffer = new ArrayBuffer(1);
   array: Array<u8> = new Array<u8>();
   map: Map<string, Array<i32>> = new Map<string, Array<i32>>();
+  nullableArray: Array<u8> | null;
+  nullableMap: Map<string, Array<i32>> | null;
 
   init(): void {
     this.nil = null;
+    this.bool = true;
     this.int8 = -128;
     this.int16 = -32768;
     this.int32 = -2147483648;
@@ -35,6 +39,11 @@ class CodecTest {
     this.map = new Map<string, Array<i32>>();
     this.map.set("foo", [1, -1, 42]);
     this.map.set("baz", [12412, -98987]);
+    this.nullableArray = [1, 2, 3];
+    const nullableMap = new Map<string, Array<i32>>();
+    nullableMap.set("toto", [1, 2]);
+    nullableMap.set("titi", [3, 4]);
+    this.nullableMap = new Map<string, Array<i32>>();
   }
 
   decode(reader: Decoder): void {
@@ -47,6 +56,8 @@ class CodecTest {
       if (field == "nil") {
         expect(reader.isNextNil()).toBeTruthy();
         this.nil = null;
+      } else if (field == "bool") {
+        this.bool = reader.readBool();
       } else if (field == "int8") {
         this.int8 = reader.readInt8();
       } else if (field == "int16") {
@@ -73,21 +84,40 @@ class CodecTest {
         this.bytes = reader.readByteArray();
       } else if (field == "array") {
         this.array = reader.readArray(
-          (decoder: Decoder): u8 => {
-            return decoder.readUInt8();
+          (decoder: SafeDecoder): u8 => {
+            return decoder.readUInt8().unwrap();
           }
         );
       } else if (field == "map") {
         this.map = reader.readMap(
-          (decoder: Decoder): string => {
-            return decoder.readString();
+          (decoder: SafeDecoder): string => {
+            return decoder.readString().unwrap();
           },
-          (decoder: Decoder): Array<i32> => {
+          (decoder: SafeDecoder): Array<i32> => {
             return decoder.readArray(
-              (decoder: Decoder): i32 => {
-                return decoder.readInt32();
+              (decoder: SafeDecoder): i32 => {
+                return decoder.readInt32().unwrap();
               }
-            );
+            ).unwrap();
+          }
+        );
+      } else if (field == "nullableArray") {
+        this.nullableArray = reader.readNullableArray(
+          (decoder: SafeDecoder): u8 => {
+            return decoder.readUInt8().unwrap();
+          }
+        );
+      } else if (field == "nullableMap") {
+        this.nullableMap = reader.readNullableMap(
+          (decoder: SafeDecoder): string => {
+            return decoder.readString().unwrap();
+          },
+          (decoder: SafeDecoder): Array<i32> => {
+            return decoder.readArray(
+              (decoder: SafeDecoder): i32 => {
+                return decoder.readInt32().unwrap();
+              }
+            ).unwrap();
           }
         );
       } else {
@@ -97,7 +127,7 @@ class CodecTest {
   }
 
   encode(writer: Writer): void {
-    writer.writeMapSize(16);
+    writer.writeMapSize(19);
 
     // Add some nested data that must be skipped.
     // This tests skipping over unknown fields.
@@ -119,6 +149,8 @@ class CodecTest {
 
     writer.writeString("nil");
     writer.writeNil();
+    writer.writeString("bool");
+    writer.writeBool(this.bool);
     writer.writeString("int8");
     writer.writeInt8(this.int8);
     writer.writeString("int16");
@@ -157,6 +189,28 @@ class CodecTest {
         writer.writeArray(value, (writer: Writer, item: i32) => {
           writer.writeInt32(item);
         });
+      }
+    );
+    writer.writeString("nullableArray");
+    writer.writeNullableArray(
+      this.nullableArray,
+      (writer: Writer, item: u8) => {
+        writer.writeUInt8(item);
+      },
+    );
+    writer.writeString("nullableMap");
+    writer.writeNullableMap(
+      this.nullableMap,
+      (writer: Writer, key: string): void => {
+        writer.writeString(key);
+      },
+      (writer: Writer, value: Array<i32>) => {
+        writer.writeArray(
+          value,
+          (writer: Writer, item: i32) => {
+            writer.writeInt32(item);
+          },
+        );
       }
     );
   }

--- a/assembly/__tests__/msgpack.spec.ts
+++ b/assembly/__tests__/msgpack.spec.ts
@@ -1,4 +1,4 @@
-import { SafeDecoder, Decoder, Writer, Encoder, Sizer } from "..";
+import { Decoder, Writer, Encoder, Sizer } from "..";
 
 class CodecTest {
   nil: string | null = "null";
@@ -84,40 +84,40 @@ class CodecTest {
         this.bytes = reader.readByteArray();
       } else if (field == "array") {
         this.array = reader.readArray(
-          (decoder: SafeDecoder): u8 => {
-            return decoder.readUInt8().unwrap();
+          (decoder: Decoder): u8 => {
+            return decoder.readUInt8();
           }
         );
       } else if (field == "map") {
         this.map = reader.readMap(
-          (decoder: SafeDecoder): string => {
-            return decoder.readString().unwrap();
+          (decoder: Decoder): string => {
+            return decoder.readString();
           },
-          (decoder: SafeDecoder): Array<i32> => {
+          (decoder: Decoder): Array<i32> => {
             return decoder.readArray(
-              (decoder: SafeDecoder): i32 => {
-                return decoder.readInt32().unwrap();
+              (decoder: Decoder): i32 => {
+                return decoder.readInt32();
               }
-            ).unwrap();
+            );
           }
         );
       } else if (field == "nullableArray") {
         this.nullableArray = reader.readNullableArray(
-          (decoder: SafeDecoder): u8 => {
-            return decoder.readUInt8().unwrap();
+          (decoder: Decoder): u8 => {
+            return decoder.readUInt8();
           }
         );
       } else if (field == "nullableMap") {
         this.nullableMap = reader.readNullableMap(
-          (decoder: SafeDecoder): string => {
-            return decoder.readString().unwrap();
+          (decoder: Decoder): string => {
+            return decoder.readString();
           },
-          (decoder: SafeDecoder): Array<i32> => {
+          (decoder: Decoder): Array<i32> => {
             return decoder.readArray(
-              (decoder: SafeDecoder): i32 => {
-                return decoder.readInt32().unwrap();
+              (decoder: Decoder): i32 => {
+                return decoder.readInt32();
               }
-            ).unwrap();
+            );
           }
         );
       } else {

--- a/assembly/__tests__/result.spec.ts
+++ b/assembly/__tests__/result.spec.ts
@@ -3,35 +3,36 @@ import {Result} from '../result';
 describe("Result", () => {
   describe("unwrap", () => {
     it("returns t when Ok(T)", () => {
-      expect(Result.ok<i32, string>(1).unwrap()).toBe(1);
+      expect(Result.ok<i32>(1).unwrap()).toBe(1);
     });
 
     it("throws when Err(E)", () => {
       expect(() => {
-        Result.err<i32, string>("boom").unwrap();
+        Result.err<i32>(new Error("boom")).unwrap();
       }).toThrow();
     });
   });
 
   describe("unwrapErr", () => {
     it("returns e when Err(E)", () => {
-      expect(Result.err<i32, string>("boom").unwrapErr()).toBe("boom");
+      const err = new Error("boom");
+      expect(Result.err<i32>(err).unwrapErr()).toBe(err);
     });
 
     it("throws when Ok(T)", () => {
       expect(() => {
-        Result.ok<i32, string>(1).unwrapErr();
+        Result.ok<i32>(1).unwrapErr();
       }).toThrow();
     });
   });
 
   describe("unwrapOr", () => {
     it("returns t when Ok(T)", () => {
-      expect(Result.ok<i32, string>(1).unwrapOr(2)).toBe(1);
+      expect(Result.ok<i32>(1).unwrapOr(2)).toBe(1);
     });
 
     it("returns the default value when Err(E)", () => {
-      expect(Result.err<i32, string>("boom").unwrapOr(2)).toBe(2);
+      expect(Result.err<i32>(new Error("boom")).unwrapOr(2)).toBe(2);
     });
   });
 });

--- a/assembly/__tests__/result.spec.ts
+++ b/assembly/__tests__/result.spec.ts
@@ -13,13 +13,25 @@ describe("Result", () => {
     });
   });
 
-  describe("unwrap_or", () => {
+  describe("unwrapErr", () => {
+    it("returns e when Err(E)", () => {
+      expect(Result.err<i32, string>("boom").unwrapErr()).toBe("boom");
+    });
+
+    it("throws when Ok(T)", () => {
+      expect(() => {
+        Result.ok<i32, string>(1).unwrapErr();
+      }).toThrow();
+    });
+  });
+
+  describe("unwrapOr", () => {
     it("returns t when Ok(T)", () => {
-      expect(Result.ok<i32, string>(1).unwrap_or(2)).toBe(1);
+      expect(Result.ok<i32, string>(1).unwrapOr(2)).toBe(1);
     });
 
     it("returns the default value when Err(E)", () => {
-      expect(Result.err<i32, string>("boom").unwrap_or(2)).toBe(2);
+      expect(Result.err<i32, string>("boom").unwrapOr(2)).toBe(2);
     });
   });
 });

--- a/assembly/__tests__/result.spec.ts
+++ b/assembly/__tests__/result.spec.ts
@@ -25,14 +25,4 @@ describe("Result", () => {
       }).toThrow();
     });
   });
-
-  describe("unwrapOr", () => {
-    it("returns t when Ok(T)", () => {
-      expect(Result.ok<i32>(1).unwrapOr(2)).toBe(1);
-    });
-
-    it("returns the default value when Err(E)", () => {
-      expect(Result.err<i32>(new Error("boom")).unwrapOr(2)).toBe(2);
-    });
-  });
 });

--- a/assembly/__tests__/result.spec.ts
+++ b/assembly/__tests__/result.spec.ts
@@ -1,0 +1,25 @@
+import {Result} from '../result';
+
+describe("Result", () => {
+  describe("unwrap", () => {
+    it("returns t when Ok(T)", () => {
+      expect(Result.ok<i32, string>(1).unwrap()).toBe(1);
+    });
+
+    it("throws when Err(E)", () => {
+      expect(() => {
+        Result.err<i32, string>("boom").unwrap();
+      }).toThrow();
+    });
+  });
+
+  describe("unwrap_or", () => {
+    it("returns t when Ok(T)", () => {
+      expect(Result.ok<i32, string>(1).unwrap_or(2)).toBe(1);
+    });
+
+    it("returns the default value when Err(E)", () => {
+      expect(Result.err<i32, string>("boom").unwrap_or(2)).toBe(2);
+    });
+  });
+});

--- a/assembly/decoder.ts
+++ b/assembly/decoder.ts
@@ -155,7 +155,12 @@ export class SafeDecoder {
   }
 
   readInt8(): Result<i8> {
-    const value = this.readInt64().unwrap(); // todo
+    const result = this.readInt64()
+    if (result.isErr) {
+      return Result.err<i8>(result.unwrapErr());
+    }
+    const value = result.unwrap();
+
     if (value <= <i64>i8.MAX_VALUE && value >= <i64>i8.MIN_VALUE) {
       return Result.ok<i8>(<i8>value);
     }
@@ -165,7 +170,12 @@ export class SafeDecoder {
   }
 
   readInt16(): Result<i16> {
-    const value = this.readInt64().unwrap(); // todo
+    const result = this.readInt64()
+    if (result.isErr) {
+      return Result.err<i16>(result.unwrapErr());
+    }
+    const value = result.unwrap();
+
     if (value <= <i64>i16.MAX_VALUE && value >= <i64>i16.MIN_VALUE) {
       return Result.ok<i16>(<i16>value);
     }
@@ -175,7 +185,12 @@ export class SafeDecoder {
   }
 
   readInt32(): Result<i32> {
-    const value = this.readInt64().unwrap(); // todo
+    const result = this.readInt64()
+    if (result.isErr) {
+      return Result.err<i32>(result.unwrapErr());
+    }
+    const value = result.unwrap();
+
     if (value <= <i64>i32.MAX_VALUE && value >= <i64>i32.MIN_VALUE) {
       return Result.ok<i32>(<i32>value);
     }
@@ -224,7 +239,12 @@ export class SafeDecoder {
   }
 
   readUInt8(): Result<u8> {
-    const value = this.readUInt64().unwrap(); // todo
+    const result = this.readUInt64()
+    if (result.isErr) {
+      return Result.err<u8>(result.unwrapErr());
+    }
+    const value = result.unwrap();
+
     if (value <= <u64>u8.MAX_VALUE) {
       return Result.ok<u8>(<u8>value);
     }
@@ -234,7 +254,12 @@ export class SafeDecoder {
   }
 
   readUInt16(): Result<u16> {
-    const value = this.readUInt64().unwrap(); // todo
+    const result = this.readUInt64()
+    if (result.isErr) {
+      return Result.err<u16>(result.unwrapErr());
+    }
+    const value = result.unwrap();
+
     if (value <= <u64>u16.MAX_VALUE) {
       return Result.ok<u16>(<u16>value);
     }
@@ -244,7 +269,12 @@ export class SafeDecoder {
   }
 
   readUInt32(): Result<u32> {
-    const value = this.readUInt64().unwrap(); // todo
+    const result = this.readUInt64()
+    if (result.isErr) {
+      return Result.err<u32>(result.unwrapErr());
+    }
+    const value = result.unwrap();
+
     if (value <= <u64>u32.MAX_VALUE) {
       return Result.ok<u32>(<u32>value);
     }

--- a/assembly/decoder.ts
+++ b/assembly/decoder.ts
@@ -626,8 +626,11 @@ export class SafeDecoder {
     const size = result.unwrap();
     let a = new Array<T>();
     for (let i: u32 = 0; i < size; i++) {
-      const item = fn(this).unwrap();
-      a.push(item);
+      const itemResult = fn(this);
+      if (itemResult.isErr) {
+        return Result.err<Array<T>>(itemResult.unwrapErr());
+      }
+      a.push(itemResult);
     }
     return Result.ok<Array<T>>(a);
   }
@@ -657,8 +660,14 @@ export class SafeDecoder {
     const size = result.unwrap();
     let m = new Map<K, V>();
     for (let i: u32 = 0; i < size; i++) {
-      const key = keyFn(this).unwrap(); // todo
-      const value = valueFn(this).unwrap(); // todo
+      const keyResult = keyFn(this);
+      if (keyResult.isErr) {
+        return Result.err<Map<K, V>>(keyResult.unwrapErr());
+      }
+      const valueResult = valueFn(this)
+      if (valueResult.isErr) {
+        return Result.err<Map<K, V>>(valueResult.unwrapErr());
+      }
       m.set(key, value);
     }
     return Result.ok<Map<K, V>>(m);

--- a/assembly/decoder.ts
+++ b/assembly/decoder.ts
@@ -1,8 +1,110 @@
 import { DataReader } from "./datareader";
 import { Format } from "./format";
+import { Result } from "./result";
 import { E_INVALIDLENGTH } from "util/error";
 
+
 export class Decoder {
+  private readonly decoder: SafeDecoder;
+
+  constructor(ua: ArrayBuffer) {
+    this.decoder = new SafeDecoder(ua);
+  }
+
+  isNextNil(): bool {
+    return this.decoder.isNextNil();
+  }
+
+  readBool(): bool {
+    return this.decoder.readBool().unwrap();
+  }
+
+  readInt8(): i8 {
+    return this.decoder.readInt8().unwrap();
+  }
+
+  readInt16(): i16 {
+    return this.decoder.readInt16().unwrap();
+  }
+
+  readInt32(): i32 {
+    return this.decoder.readInt32().unwrap();
+  }
+
+  readInt64(): i64 {
+    return this.decoder.readInt64().unwrap();
+  }
+
+  readUInt8(): u8 {
+    return this.decoder.readUInt8().unwrap();
+  }
+
+  readUInt16(): u16 {
+    return this.decoder.readUInt16().unwrap();
+  }
+
+  readUInt32(): u32 {
+    return this.decoder.readUInt32().unwrap();
+  }
+
+  readUInt64(): u64 {
+    return this.decoder.readUInt64().unwrap();
+  }
+
+  readFloat32(): f32 {
+    return this.decoder.readFloat32().unwrap();
+  }
+
+  readFloat64(): f64 {
+    return this.decoder.readFloat64().unwrap();
+  }
+
+  readString(): string {
+    return this.decoder.readString().unwrap();
+  }
+
+  readStringLength(): u32 {
+    return this.decoder.readStringLength();
+  }
+
+  readBinLength(): u32 {
+    return this.decoder.readBinLength();
+  }
+
+  readByteArray(): ArrayBuffer {
+    return this.decoder.readByteArray().unwrap();
+  }
+
+  readArraySize(): u32 {
+    return this.decoder.readArraySize();
+  }
+
+  readMapSize(): u32 {
+    return this.decoder.readMapSize().unwrap();
+  }
+
+  readArray<T>(fn: (decoder: SafeDecoder) => T): Array<T> {
+    return this.decoder.readArray(fn).unwrap();
+  }
+
+  readNullableArray<T>(fn: (decoder: SafeDecoder) => T): Array<T> | null {
+    return this.decoder.readNullableArray(fn);
+  }
+
+  readMap<K, V>(keyFn: (decoder: SafeDecoder) => K, valueFn: (decoder: SafeDecoder) => V): Map<K, V> {
+    return this.decoder.readMap(keyFn, valueFn).unwrap();
+  }
+
+  readNullableMap<K, V>(keyFn: (decoder: SafeDecoder) => K, valueFn: (decoder: SafeDecoder) => V): Map<K, V> | null {
+    return this.decoder.readNullableMap(keyFn, valueFn);
+  }
+
+  skip(): void {
+    this.decoder.skip();
+  }
+}
+
+export class SafeDecoder {
   private reader: DataReader;
 
   constructor(ua: ArrayBuffer) {
@@ -17,307 +119,320 @@ export class Decoder {
     return false;
   }
 
-  readBool(): bool {
+  readBool(): Result<bool, Error> {
     const value = this.reader.getUint8();
     if (value == Format.TRUE) {
-      return true;
+      return Result.ok<bool, Error>(true);
     } else if (value == Format.FALSE) {
-      return false;
+      return Result.ok<bool, Error>(false);
     }
-    throw new Error("bad value for bool");
+    return Result.err<bool, Error>(new Error("bad value for bool"));
   }
 
-  readInt8(): i8 {
-    const value = this.readInt64();
+  readInt8(): Result<i8, Error> {
+    const value = this.readInt64().unwrap();
     if (value <= <i64>i8.MAX_VALUE && value >= <i64>i8.MIN_VALUE) {
-      return <i8>value;
+      return Result.ok<i8, Error>(<i8>value);
     }
-    throw new Error(
+    return Result.err<i8, Error>(new Error(
       "interger overflow: value = " + value.toString() + "; bits = 8"
-    );
-  }
-  readInt16(): i16 {
-    const value = this.readInt64();
-    if (value <= <i64>i16.MAX_VALUE && value >= <i64>i16.MIN_VALUE) {
-      return <i16>value;
-    }
-    throw new Error(
-      "interger overflow: value = " + value.toString() + "; bits = 16"
-    );
-  }
-  readInt32(): i32 {
-    const value = this.readInt64();
-    if (value <= <i64>i32.MAX_VALUE && value >= <i64>i32.MIN_VALUE) {
-      return <i32>value;
-    }
-    throw new Error(
-      "interger overflow: value = " + value.toString() + "; bits = 32"
-    );
+    ));
   }
 
-  readInt64(): i64 {
+  readInt16(): Result<i16, Error> {
+    const value = this.readInt64().unwrap();
+    if (value <= <i64>i16.MAX_VALUE && value >= <i64>i16.MIN_VALUE) {
+      return Result.ok<i16, Error>(<i16>value);
+    }
+    return Result.err<i16, Error>(new Error(
+      "interger overflow: value = " + value.toString() + "; bits = 16"
+    ));
+  }
+
+  readInt32(): Result<i32, Error> {
+    const value = this.readInt64().unwrap();
+    if (value <= <i64>i32.MAX_VALUE && value >= <i64>i32.MIN_VALUE) {
+      return Result.ok<i32, Error>(<i32>value);
+    }
+    return Result.err<i32, Error>(new Error(
+      "interger overflow: value = " + value.toString() + "; bits = 32"
+    ));
+  }
+
+  readInt64(): Result<i64, Error> {
     const prefix = this.reader.getUint8();
 
     if (this.isFixedInt(prefix)) {
-      return <i64>prefix;
+      return Result.ok<i64, Error>(<i64>prefix);
     }
     if (this.isNegativeFixedInt(prefix)) {
-      return <i64>(<i8>prefix);
+      return Result.ok<i64, Error>(<i64>(<i8>prefix));
     }
     switch (prefix) {
       case Format.INT8:
-        return <i64>this.reader.getInt8();
+        return Result.ok<i64, Error>(<i64>this.reader.getInt8());
       case Format.INT16:
-        return <i64>this.reader.getInt16();
+        return Result.ok<i64, Error>(<i64>this.reader.getInt16());
       case Format.INT32:
-        return <i64>this.reader.getInt32();
+        return Result.ok<i64, Error>(<i64>this.reader.getInt32());
       case Format.INT64:
-        return this.reader.getInt64();
+        return Result.ok<i64, Error>(this.reader.getInt64());
       case Format.UINT8:
-        return <i64>this.reader.getUint8();
+        return Result.ok<i64, Error>(<i64>this.reader.getUint8());
       case Format.UINT16:
-        return <i64>this.reader.getUint16();
+        return Result.ok<i64, Error>(<i64>this.reader.getUint16());
       case Format.UINT32:
-        return <i64>this.reader.getUint32();
+        return Result.ok<i64, Error>(<i64>this.reader.getUint32());
       case Format.UINT64: {
         const value = this.reader.getUint64();
         if (value <= <u64>i64.MAX_VALUE) {
-          return <i64>value;
+          return Result.ok<i64, Error>(<i64>value);
         }
-        throw new Error(
+
+        return Result.err<i64, Error>(new Error(
           "interger overflow: value = " + value.toString() + "; type = i64"
-        );
+        ));
       }
       default:
-        throw new Error("bad prefix for int");
+        return Result.err<i64, Error>(new Error("bad prefix for int"));
     }
   }
 
-  readUInt8(): u8 {
-    const value = this.readUInt64();
+  readUInt8(): Result<u8, Error> {
+    const value = this.readUInt64().unwrap();
     if (value <= <u64>u8.MAX_VALUE) {
-      return <u8>value;
+      return Result.ok<u8, Error>(<u8>value);
     }
-    throw new Error(
+    return Result.err<u8, Error>(new Error(
       "unsigned interger overflow: value = " + value.toString() + "; bits = 8"
-    );
+    ));
   }
 
-  readUInt16(): u16 {
-    const value = this.readUInt64();
+  readUInt16(): Result<u16, Error> {
+    const value = this.readUInt64().unwrap();
     if (value <= <u64>u16.MAX_VALUE) {
-      return <u16>value;
+      return Result.ok<u16, Error>(<u16>value);
     }
-    throw new Error(
+    return Result.err<u16, Error>(new Error(
       "unsigned interger overflow: value = " + value.toString() + "; bits = 16"
-    );
+    ));
   }
 
-  readUInt32(): u32 {
-    const value = this.readUInt64();
+  readUInt32(): Result<u32, Error> {
+    const value = this.readUInt64().unwrap();
     if (value <= <u64>u32.MAX_VALUE) {
-      return <u32>value;
+      return Result.ok<u32, Error>(<u32>value);
     }
-    throw new Error(
+    return Result.err<u32, Error>(new Error(
       "unsigned interger overflow: value = " + value.toString() + "; bits = 32"
-    );
+    ));
   }
 
-  readUInt64(): u64 {
+  readUInt64(): Result<u64, Error> {
     const prefix = this.reader.getUint8();
 
     if (this.isFixedInt(prefix)) {
-      return <u64>prefix;
+      return Result.ok<u64, Error>(<u64>prefix);
     } else if (this.isNegativeFixedInt(prefix)) {
-      throw new Error("bad prefix");
+      return Result.err<u64, Error>(new Error("bad prefix"));
     }
 
     switch (prefix) {
       case Format.UINT8:
-        return <u64>this.reader.getUint8();
+        return Result.ok<u64, Error>(<u64>this.reader.getUint8());
       case Format.UINT16:
-        return <u64>this.reader.getUint16();
+        return Result.ok<u64, Error>(<u64>this.reader.getUint16());
       case Format.UINT32:
-        return <u64>this.reader.getUint32();
+        return Result.ok<u64, Error>(<u64>this.reader.getUint32());
       case Format.UINT64:
-        return this.reader.getUint64();
+        return Result.ok<u64, Error>(this.reader.getUint64());
       case Format.INT8: {
         const value = this.reader.getInt8();
         if (value >= 0) {
-          return <u64>value;
+          return Result.ok<u64, Error>(<u64>value);
         }
-        throw new Error(
+        return Result.err<u64, Error>(new Error(
           "interger underflow: value = " + value.toString() + "; type = u64"
-        );
+        ));
       }
       case Format.INT16:
         const value = this.reader.getInt16();
         if (value >= 0) {
-          return <u64>value;
+          return Result.ok<u64, Error>(<u64>value);
         }
-        throw new Error(
+        return Result.err<u64, Error>(new Error(
           "interger underflow: value = " + value.toString() + "; type = u64"
-        );
+        ));
       case Format.INT32:
         const value = this.reader.getInt32();
         if (value >= 0) {
-          return <u64>value;
+          return Result.ok<u64, Error>(<u64>value);
         }
-        throw new Error(
+        return Result.err<u64, Error>(new Error(
           "interger underflow: value = " + value.toString() + "; type = u64"
-        );
+        ));
       case Format.INT64:
         const value = this.reader.getInt64();
         if (value >= 0) {
-          return <u64>value;
+          return Result.ok<u64, Error>(<u64>value);
         }
-        throw new Error(
+        return Result.err<u64, Error>(new Error(
           "interger underflow: value = " + value.toString() + "; type = u64"
-        );
+        ));
       default:
-        throw new Error("bad prefix for int");
+        return Result.err<u64, Error>(new Error("bad prefix for int"));
     }
   }
 
-  readFloat32(): f32 {
+  readFloat32(): Result<f32, Error> {
     const prefix = this.reader.getUint8();
     if (this.isFloat32(prefix)) {
-      return <f32>this.reader.getFloat32();
+      return Result.ok<f32, Error>(<f32>this.reader.getFloat32());
     } else if (this.isFloat64(prefix)) {
       const value = this.reader.getFloat64();
       const diff = <f64>f32.MAX_VALUE - value;
 
       if (abs(diff) <= <f64>f32.EPSILON) {
-        return f32.MAX_VALUE;
+        return Result.ok<f32, Error>(f32.MAX_VALUE);
       } else if (diff < 0) {
-        throw new Error(
+        return Result.err<f32, Error>(new Error(
           "float overflow: value = " + value.toString() + "; type = f32"
-        );
+        ));
       } else {
-        return <f32>value;
+        return Result.ok<f32, Error>(<f32>value);
       }
     } else {
-      throw new Error("bad prefix for float");
+      return Result.err<f32, Error>(new Error("bad prefix for float"));
     }
   }
 
-  readFloat64(): f64 {
+  readFloat64(): Result<f64, Error> {
     const prefix = this.reader.getUint8();
     if (this.isFloat64(prefix)) {
-      return <f64>this.reader.getFloat64();
+      return Result.ok<f64, Error>(<f64>this.reader.getFloat64());
     } else if (this.isFloat32(prefix)) {
-      return <f64>this.reader.getFloat32();
+      return Result.ok<f64, Error>(<f64>this.reader.getFloat32());
     } else {
-      throw new Error("bad prefix for float");
+      return Result.err<f64, Error>(new Error("bad prefix for float"));
     }
   }
 
-  readString(): string {
-    const strLen = this.readStringLength();
+  readString(): Result<string, Error> {
+    const result = this.readStringLength();
+    if (result.isErr) {
+      return Result.err<string, Error>(result.unwrap_err());
+    }
+
+    const strLen = result.unwrap();
     const stringBytes = this.reader.getBytes(strLen);
-    return String.UTF8.decode(stringBytes);
+    return Result.ok<string, Error>(String.UTF8.decode(stringBytes));
   }
 
-  readStringLength(): u32 {
+  readStringLength(): Result<u32, Error> {
     const leadByte = this.reader.getUint8();
     if (this.isFixedString(leadByte)) {
-      return leadByte & 0x1f;
+      return Result.ok<u32, Error>(leadByte & 0x1f);
     }
     if (this.isFixedArray(leadByte)) {
-      return <u32>(leadByte & Format.FOUR_LEAST_SIG_BITS_IN_BYTE);
+      return Result.ok<u32, Error>(<u32>(leadByte & Format.FOUR_LEAST_SIG_BITS_IN_BYTE));
     }
     switch (leadByte) {
       case Format.STR8:
-        return <u32>this.reader.getUint8();
+        return Result.ok<u32, Error>(<u32>this.reader.getUint8());
       case Format.STR16:
-        return <u32>this.reader.getUint16();
+        return Result.ok<u32, Error>(<u32>this.reader.getUint16());
       case Format.STR32:
-        return this.reader.getUint32();
+        return Result.ok<u32, Error>(this.reader.getUint32());
     }
 
-    throw new RangeError(E_INVALIDLENGTH + leadByte.toString());
+    return Result.err<u32, Error>(new RangeError(E_INVALIDLENGTH + leadByte.toString()));
   }
 
-  readBinLength(): u32 {
+  readBinLength(): Result<u32, Error> {
     if (this.isNextNil()) {
-      return 0;
+      return Result.ok<u32, Error>(0);
     }
     const leadByte = this.reader.getUint8();
     if (this.isFixedArray(leadByte)) {
-      return <u32>(leadByte & Format.FOUR_LEAST_SIG_BITS_IN_BYTE);
+      return Result.ok<u32, Error>(<u32>(leadByte & Format.FOUR_LEAST_SIG_BITS_IN_BYTE));
     }
     switch (leadByte) {
       case Format.BIN8:
-        return <u32>this.reader.getUint8();
+        return Result.ok<u32, Error>(<u32>this.reader.getUint8());
       case Format.BIN16:
-        return <u32>this.reader.getUint16();
+        return Result.ok<u32, Error>(<u32>this.reader.getUint16());
       case Format.BIN32:
-        return this.reader.getUint32();
+        return Result.ok<u32, Error>(this.reader.getUint32());
     }
-    throw new RangeError(E_INVALIDLENGTH);
+    return Result.err<u32, Error>(new RangeError(E_INVALIDLENGTH));
   }
 
-  readByteArray(): ArrayBuffer {
-    const arrLength = this.readBinLength();
+  readByteArray(): Result<ArrayBuffer, Error> {
+    const result = this.readBinLength();
+    if (result.isErr) {
+      return Result.err<ArrayBuffer, Error>(result.unwrap_err());
+    }
+
+    const arrLength = result.unwrap();
     const arrBytes = this.reader.getBytes(arrLength);
-    return arrBytes;
+    return Result.ok<ArrayBuffer, Error>(arrBytes);
   }
 
-  readArraySize(): u32 {
+  readArraySize(): Result<u32, Error> {
     const leadByte = this.reader.getUint8();
     if (this.isFixedArray(leadByte)) {
-      return <u32>(leadByte & Format.FOUR_LEAST_SIG_BITS_IN_BYTE);
+      return Result.ok<u32, Error>(<u32>(leadByte & Format.FOUR_LEAST_SIG_BITS_IN_BYTE));
     } else if (leadByte == Format.ARRAY16) {
-      return <u32>this.reader.getUint16();
+      return Result.ok<u32, Error>(<u32>this.reader.getUint16());
     } else if (leadByte == Format.ARRAY32) {
-      return this.reader.getUint32();
+      return Result.ok<u32, Error>(this.reader.getUint32());
     } else if (leadByte == Format.NIL) {
-      return 0;
+      return Result.ok<u32, Error>(0);
     }
-    throw new RangeError(E_INVALIDLENGTH + leadByte.toString());
+    return Result.err<u32, Error>(new RangeError(E_INVALIDLENGTH + leadByte.toString()));
   }
 
-  readMapSize(): u32 {
+  readMapSize(): Result<u32, Error> {
     const leadByte = this.reader.getUint8();
     if (this.isFixedMap(leadByte)) {
-      return <u32>(leadByte & Format.FOUR_LEAST_SIG_BITS_IN_BYTE);
+      return Result.ok<u32, Error>(<u32>(leadByte & Format.FOUR_LEAST_SIG_BITS_IN_BYTE));
     } else if (leadByte == Format.MAP16) {
-      return <u32>this.reader.getUint16();
+      return Result.ok<u32, Error>(<u32>this.reader.getUint16());
     } else if (leadByte == Format.MAP32) {
-      return this.reader.getUint32();
+      return Result.ok<u32, Error>(this.reader.getUint32());
     }
-    throw new RangeError(E_INVALIDLENGTH);
+    return Result.err<u32, Error>(new RangeError(E_INVALIDLENGTH));
   }
 
-  isFloat32(u: u8): bool {
+  private isFloat32(u: u8): bool {
     return u == Format.FLOAT32;
   }
 
-  isFloat64(u: u8): bool {
+  private isFloat64(u: u8): bool {
     return u == Format.FLOAT64;
   }
 
-  isFixedInt(u: u8): bool {
+  private isFixedInt(u: u8): bool {
     return u >> 7 == 0;
   }
 
-  isNegativeFixedInt(u: u8): bool {
+  private isNegativeFixedInt(u: u8): bool {
     return (u & 0xe0) == Format.NEGATIVE_FIXINT;
   }
 
-  isFixedMap(u: u8): bool {
+  private isFixedMap(u: u8): bool {
     return (u & 0xf0) == Format.FIXMAP;
   }
 
-  isFixedArray(u: u8): bool {
+  private isFixedArray(u: u8): bool {
     return (u & 0xf0) == Format.FIXARRAY;
   }
 
-  isFixedString(u: u8): bool {
+  private isFixedString(u: u8): bool {
     return (u & 0xe0) == Format.FIXSTR;
   }
 
-  isNil(u: u8): bool {
+  private isNil(u: u8): bool {
     return u == Format.NIL;
   }
 
@@ -331,7 +446,7 @@ export class Decoder {
     }
   }
 
-  getSize(): i32 {
+  private getSize(): i32 {
     const leadByte = this.reader.getUint8(); // will discard one
     let objectsToDiscard = <i32>0;
     // Handled for fixed values
@@ -447,44 +562,54 @@ export class Decoder {
     return objectsToDiscard;
   }
 
-  readArray<T>(fn: (decoder: Decoder) => T): Array<T> {
-    const size = this.readArraySize();
+  readArray<T>(fn: (decoder: SafeDecoder) => T): Result<Array<T>, Error> {
+    const result = this.readArraySize();
+    if (result.isErr) {
+      return Result.err<Array<T>, Error>(result.unwrap_err());
+    }
+
+    const size = result.unwrap();
     let a = new Array<T>();
     for (let i: u32 = 0; i < size; i++) {
       const item = fn(this);
       a.push(item);
     }
-    return a;
+    return Result.ok<Array<T>, Error>(a);
   }
 
-  readNullableArray<T>(fn: (decoder: Decoder) => T): Array<T> | null {
+  readNullableArray<T>(fn: (decoder: SafeDecoder) => T): Array<T> | null {
     if (this.isNextNil()) {
       return null;
     }
-    return this.readArray(fn);
+    return this.readArray(fn).unwrap();
   }
 
   readMap<K, V>(
-    keyFn: (decoder: Decoder) => K,
-    valueFn: (decoder: Decoder) => V
-  ): Map<K, V> {
-    const size = this.readMapSize();
+    keyFn: (decoder: SafeDecoder) => K,
+    valueFn: (decoder: SafeDecoder) => V
+  ): Result<Map<K, V>, Error> {
+    const result = this.readMapSize();
+    if (result.isErr) {
+      return Result.err<Map<K, V>, Error>(result.unwrap_err());
+    }
+
+    const size = result.unwrap();
     let m = new Map<K, V>();
     for (let i: u32 = 0; i < size; i++) {
       const key = keyFn(this);
       const value = valueFn(this);
       m.set(key, value);
     }
-    return m;
+    return Result.ok<Map<K, V>, Error>(m);
   }
 
   readNullableMap<K, V>(
-    keyFn: (decoder: Decoder) => K,
-    valueFn: (decoder: Decoder) => V
+    keyFn: (decoder: SafeDecoder) => K,
+    valueFn: (decoder: SafeDecoder) => V
   ): Map<K, V> | null {
     if (this.isNextNil()) {
       return null;
     }
-    return this.readMap(keyFn, valueFn);
+    return this.readMap(keyFn, valueFn).unwrap();
   }
 }

--- a/assembly/decoder.ts
+++ b/assembly/decoder.ts
@@ -117,9 +117,16 @@ export class Decoder {
     return this.readMap(keyFn, valueFn);
   }
 
-  skip(): void {
-    this.decoder.skip();
-  }
+  isFloat32(u: u8): bool { return this.decoder.isFloat32(u); }
+  isFloat64(u: u8): bool { return this.decoder.isFloat64(u); }
+  isFixedInt(u: u8): bool { return this.decoder.isFixedInt(u); }
+  isNegativeFixedInt(u: u8): bool { return this.decoder.isNegativeFixedInt(u); }
+  isFixedMap(u: u8): bool { return this.decoder.isFixedMap(u); }
+  isFixedArray(u: u8): bool { return this.decoder.isFixedArray(u); }
+  isFixedString(u: u8): bool { return this.decoder.isFixedString(u); }
+  isNil(u: u8): bool { return this.decoder.isNil(u); }
+  getSize(): u32 { return this.decoder.getSize(); }
+  skip(): void { this.decoder.skip(); }
 }
 
 export class SafeDecoder {
@@ -422,35 +429,35 @@ export class SafeDecoder {
     return Result.err<u32>(new RangeError(E_INVALIDLENGTH));
   }
 
-  private isFloat32(u: u8): bool {
+  isFloat32(u: u8): bool {
     return u == Format.FLOAT32;
   }
 
-  private isFloat64(u: u8): bool {
+  isFloat64(u: u8): bool {
     return u == Format.FLOAT64;
   }
 
-  private isFixedInt(u: u8): bool {
+  isFixedInt(u: u8): bool {
     return u >> 7 == 0;
   }
 
-  private isNegativeFixedInt(u: u8): bool {
+  isNegativeFixedInt(u: u8): bool {
     return (u & 0xe0) == Format.NEGATIVE_FIXINT;
   }
 
-  private isFixedMap(u: u8): bool {
+  isFixedMap(u: u8): bool {
     return (u & 0xf0) == Format.FIXMAP;
   }
 
-  private isFixedArray(u: u8): bool {
+  isFixedArray(u: u8): bool {
     return (u & 0xf0) == Format.FIXARRAY;
   }
 
-  private isFixedString(u: u8): bool {
+  isFixedString(u: u8): bool {
     return (u & 0xe0) == Format.FIXSTR;
   }
 
-  private isNil(u: u8): bool {
+  isNil(u: u8): bool {
     return u == Format.NIL;
   }
 
@@ -464,7 +471,7 @@ export class SafeDecoder {
     }
   }
 
-  private getSize(): i32 {
+  getSize(): i32 {
     const leadByte = this.reader.getUint8(); // will discard one
     let objectsToDiscard = <i32>0;
     // Handled for fixed values

--- a/assembly/decoder.ts
+++ b/assembly/decoder.ts
@@ -137,289 +137,289 @@ export class SafeDecoder {
     return false;
   }
 
-  readBool(): Result<bool, Error> {
+  readBool(): Result<bool> {
     const value = this.reader.getUint8();
     if (value == Format.TRUE) {
-      return Result.ok<bool, Error>(true);
+      return Result.ok<bool>(true);
     } else if (value == Format.FALSE) {
-      return Result.ok<bool, Error>(false);
+      return Result.ok<bool>(false);
     }
-    return Result.err<bool, Error>(new Error("bad value for bool"));
+    return Result.err<bool>(new Error("bad value for bool"));
   }
 
-  readInt8(): Result<i8, Error> {
-    const value = this.readInt64().unwrap();
+  readInt8(): Result<i8> {
+    const value = this.readInt64().unwrap(); // todo
     if (value <= <i64>i8.MAX_VALUE && value >= <i64>i8.MIN_VALUE) {
-      return Result.ok<i8, Error>(<i8>value);
+      return Result.ok<i8>(<i8>value);
     }
-    return Result.err<i8, Error>(new Error(
+    return Result.err<i8>(new Error(
       "interger overflow: value = " + value.toString() + "; bits = 8"
     ));
   }
 
-  readInt16(): Result<i16, Error> {
-    const value = this.readInt64().unwrap();
+  readInt16(): Result<i16> {
+    const value = this.readInt64().unwrap(); // todo
     if (value <= <i64>i16.MAX_VALUE && value >= <i64>i16.MIN_VALUE) {
-      return Result.ok<i16, Error>(<i16>value);
+      return Result.ok<i16>(<i16>value);
     }
-    return Result.err<i16, Error>(new Error(
+    return Result.err<i16>(new Error(
       "interger overflow: value = " + value.toString() + "; bits = 16"
     ));
   }
 
-  readInt32(): Result<i32, Error> {
-    const value = this.readInt64().unwrap();
+  readInt32(): Result<i32> {
+    const value = this.readInt64().unwrap(); // todo
     if (value <= <i64>i32.MAX_VALUE && value >= <i64>i32.MIN_VALUE) {
-      return Result.ok<i32, Error>(<i32>value);
+      return Result.ok<i32>(<i32>value);
     }
-    return Result.err<i32, Error>(new Error(
+    return Result.err<i32>(new Error(
       "interger overflow: value = " + value.toString() + "; bits = 32"
     ));
   }
 
-  readInt64(): Result<i64, Error> {
+  readInt64(): Result<i64> {
     const prefix = this.reader.getUint8();
 
     if (this.isFixedInt(prefix)) {
-      return Result.ok<i64, Error>(<i64>prefix);
+      return Result.ok<i64>(<i64>prefix);
     }
     if (this.isNegativeFixedInt(prefix)) {
-      return Result.ok<i64, Error>(<i64>(<i8>prefix));
+      return Result.ok<i64>(<i64>(<i8>prefix));
     }
     switch (prefix) {
       case Format.INT8:
-        return Result.ok<i64, Error>(<i64>this.reader.getInt8());
+        return Result.ok<i64>(<i64>this.reader.getInt8());
       case Format.INT16:
-        return Result.ok<i64, Error>(<i64>this.reader.getInt16());
+        return Result.ok<i64>(<i64>this.reader.getInt16());
       case Format.INT32:
-        return Result.ok<i64, Error>(<i64>this.reader.getInt32());
+        return Result.ok<i64>(<i64>this.reader.getInt32());
       case Format.INT64:
-        return Result.ok<i64, Error>(this.reader.getInt64());
+        return Result.ok<i64>(this.reader.getInt64());
       case Format.UINT8:
-        return Result.ok<i64, Error>(<i64>this.reader.getUint8());
+        return Result.ok<i64>(<i64>this.reader.getUint8());
       case Format.UINT16:
-        return Result.ok<i64, Error>(<i64>this.reader.getUint16());
+        return Result.ok<i64>(<i64>this.reader.getUint16());
       case Format.UINT32:
-        return Result.ok<i64, Error>(<i64>this.reader.getUint32());
+        return Result.ok<i64>(<i64>this.reader.getUint32());
       case Format.UINT64: {
         const value = this.reader.getUint64();
         if (value <= <u64>i64.MAX_VALUE) {
-          return Result.ok<i64, Error>(<i64>value);
+          return Result.ok<i64>(<i64>value);
         }
 
-        return Result.err<i64, Error>(new Error(
+        return Result.err<i64>(new Error(
           "interger overflow: value = " + value.toString() + "; type = i64"
         ));
       }
       default:
-        return Result.err<i64, Error>(new Error("bad prefix for int"));
+        return Result.err<i64>(new Error("bad prefix for int"));
     }
   }
 
-  readUInt8(): Result<u8, Error> {
-    const value = this.readUInt64().unwrap();
+  readUInt8(): Result<u8> {
+    const value = this.readUInt64().unwrap(); // todo
     if (value <= <u64>u8.MAX_VALUE) {
-      return Result.ok<u8, Error>(<u8>value);
+      return Result.ok<u8>(<u8>value);
     }
-    return Result.err<u8, Error>(new Error(
+    return Result.err<u8>(new Error(
       "unsigned interger overflow: value = " + value.toString() + "; bits = 8"
     ));
   }
 
-  readUInt16(): Result<u16, Error> {
-    const value = this.readUInt64().unwrap();
+  readUInt16(): Result<u16> {
+    const value = this.readUInt64().unwrap(); // todo
     if (value <= <u64>u16.MAX_VALUE) {
-      return Result.ok<u16, Error>(<u16>value);
+      return Result.ok<u16>(<u16>value);
     }
-    return Result.err<u16, Error>(new Error(
+    return Result.err<u16>(new Error(
       "unsigned interger overflow: value = " + value.toString() + "; bits = 16"
     ));
   }
 
-  readUInt32(): Result<u32, Error> {
-    const value = this.readUInt64().unwrap();
+  readUInt32(): Result<u32> {
+    const value = this.readUInt64().unwrap(); // todo
     if (value <= <u64>u32.MAX_VALUE) {
-      return Result.ok<u32, Error>(<u32>value);
+      return Result.ok<u32>(<u32>value);
     }
-    return Result.err<u32, Error>(new Error(
+    return Result.err<u32>(new Error(
       "unsigned interger overflow: value = " + value.toString() + "; bits = 32"
     ));
   }
 
-  readUInt64(): Result<u64, Error> {
+  readUInt64(): Result<u64> {
     const prefix = this.reader.getUint8();
 
     if (this.isFixedInt(prefix)) {
-      return Result.ok<u64, Error>(<u64>prefix);
+      return Result.ok<u64>(<u64>prefix);
     } else if (this.isNegativeFixedInt(prefix)) {
-      return Result.err<u64, Error>(new Error("bad prefix"));
+      return Result.err<u64>(new Error("bad prefix"));
     }
 
     switch (prefix) {
       case Format.UINT8:
-        return Result.ok<u64, Error>(<u64>this.reader.getUint8());
+        return Result.ok<u64>(<u64>this.reader.getUint8());
       case Format.UINT16:
-        return Result.ok<u64, Error>(<u64>this.reader.getUint16());
+        return Result.ok<u64>(<u64>this.reader.getUint16());
       case Format.UINT32:
-        return Result.ok<u64, Error>(<u64>this.reader.getUint32());
+        return Result.ok<u64>(<u64>this.reader.getUint32());
       case Format.UINT64:
-        return Result.ok<u64, Error>(this.reader.getUint64());
+        return Result.ok<u64>(this.reader.getUint64());
       case Format.INT8: {
         const value = this.reader.getInt8();
         if (value >= 0) {
-          return Result.ok<u64, Error>(<u64>value);
+          return Result.ok<u64>(<u64>value);
         }
-        return Result.err<u64, Error>(new Error(
+        return Result.err<u64>(new Error(
           "interger underflow: value = " + value.toString() + "; type = u64"
         ));
       }
       case Format.INT16:
         const value = this.reader.getInt16();
         if (value >= 0) {
-          return Result.ok<u64, Error>(<u64>value);
+          return Result.ok<u64>(<u64>value);
         }
-        return Result.err<u64, Error>(new Error(
+        return Result.err<u64>(new Error(
           "interger underflow: value = " + value.toString() + "; type = u64"
         ));
       case Format.INT32:
         const value = this.reader.getInt32();
         if (value >= 0) {
-          return Result.ok<u64, Error>(<u64>value);
+          return Result.ok<u64>(<u64>value);
         }
-        return Result.err<u64, Error>(new Error(
+        return Result.err<u64>(new Error(
           "interger underflow: value = " + value.toString() + "; type = u64"
         ));
       case Format.INT64:
         const value = this.reader.getInt64();
         if (value >= 0) {
-          return Result.ok<u64, Error>(<u64>value);
+          return Result.ok<u64>(<u64>value);
         }
-        return Result.err<u64, Error>(new Error(
+        return Result.err<u64>(new Error(
           "interger underflow: value = " + value.toString() + "; type = u64"
         ));
       default:
-        return Result.err<u64, Error>(new Error("bad prefix for int"));
+        return Result.err<u64>(new Error("bad prefix for int"));
     }
   }
 
-  readFloat32(): Result<f32, Error> {
+  readFloat32(): Result<f32> {
     const prefix = this.reader.getUint8();
     if (this.isFloat32(prefix)) {
-      return Result.ok<f32, Error>(<f32>this.reader.getFloat32());
+      return Result.ok<f32>(<f32>this.reader.getFloat32());
     } else if (this.isFloat64(prefix)) {
       const value = this.reader.getFloat64();
       const diff = <f64>f32.MAX_VALUE - value;
 
       if (abs(diff) <= <f64>f32.EPSILON) {
-        return Result.ok<f32, Error>(f32.MAX_VALUE);
+        return Result.ok<f32>(f32.MAX_VALUE);
       } else if (diff < 0) {
-        return Result.err<f32, Error>(new Error(
+        return Result.err<f32>(new Error(
           "float overflow: value = " + value.toString() + "; type = f32"
         ));
       } else {
-        return Result.ok<f32, Error>(<f32>value);
+        return Result.ok<f32>(<f32>value);
       }
     } else {
-      return Result.err<f32, Error>(new Error("bad prefix for float"));
+      return Result.err<f32>(new Error("bad prefix for float"));
     }
   }
 
-  readFloat64(): Result<f64, Error> {
+  readFloat64(): Result<f64> {
     const prefix = this.reader.getUint8();
     if (this.isFloat64(prefix)) {
-      return Result.ok<f64, Error>(<f64>this.reader.getFloat64());
+      return Result.ok<f64>(<f64>this.reader.getFloat64());
     } else if (this.isFloat32(prefix)) {
-      return Result.ok<f64, Error>(<f64>this.reader.getFloat32());
+      return Result.ok<f64>(<f64>this.reader.getFloat32());
     } else {
-      return Result.err<f64, Error>(new Error("bad prefix for float"));
+      return Result.err<f64>(new Error("bad prefix for float"));
     }
   }
 
-  readString(): Result<string, Error> {
+  readString(): Result<string> {
     const result = this.readStringLength();
     if (result.isErr) {
-      return Result.err<string, Error>(result.unwrapErr());
+      return Result.err<string>(result.unwrapErr());
     }
 
     const strLen = result.unwrap();
     const stringBytes = this.reader.getBytes(strLen);
-    return Result.ok<string, Error>(String.UTF8.decode(stringBytes));
+    return Result.ok<string>(String.UTF8.decode(stringBytes));
   }
 
-  readStringLength(): Result<u32, Error> {
+  readStringLength(): Result<u32> {
     const leadByte = this.reader.getUint8();
     if (this.isFixedString(leadByte)) {
-      return Result.ok<u32, Error>(leadByte & 0x1f);
+      return Result.ok<u32>(leadByte & 0x1f);
     }
     if (this.isFixedArray(leadByte)) {
-      return Result.ok<u32, Error>(<u32>(leadByte & Format.FOUR_LEAST_SIG_BITS_IN_BYTE));
+      return Result.ok<u32>(<u32>(leadByte & Format.FOUR_LEAST_SIG_BITS_IN_BYTE));
     }
     switch (leadByte) {
       case Format.STR8:
-        return Result.ok<u32, Error>(<u32>this.reader.getUint8());
+        return Result.ok<u32>(<u32>this.reader.getUint8());
       case Format.STR16:
-        return Result.ok<u32, Error>(<u32>this.reader.getUint16());
+        return Result.ok<u32>(<u32>this.reader.getUint16());
       case Format.STR32:
-        return Result.ok<u32, Error>(this.reader.getUint32());
+        return Result.ok<u32>(this.reader.getUint32());
     }
 
-    return Result.err<u32, Error>(new RangeError(E_INVALIDLENGTH + leadByte.toString()));
+    return Result.err<u32>(new RangeError(E_INVALIDLENGTH + leadByte.toString()));
   }
 
-  readBinLength(): Result<u32, Error> {
+  readBinLength(): Result<u32> {
     if (this.isNextNil()) {
-      return Result.ok<u32, Error>(0);
+      return Result.ok<u32>(0);
     }
     const leadByte = this.reader.getUint8();
     if (this.isFixedArray(leadByte)) {
-      return Result.ok<u32, Error>(<u32>(leadByte & Format.FOUR_LEAST_SIG_BITS_IN_BYTE));
+      return Result.ok<u32>(<u32>(leadByte & Format.FOUR_LEAST_SIG_BITS_IN_BYTE));
     }
     switch (leadByte) {
       case Format.BIN8:
-        return Result.ok<u32, Error>(<u32>this.reader.getUint8());
+        return Result.ok<u32>(<u32>this.reader.getUint8());
       case Format.BIN16:
-        return Result.ok<u32, Error>(<u32>this.reader.getUint16());
+        return Result.ok<u32>(<u32>this.reader.getUint16());
       case Format.BIN32:
-        return Result.ok<u32, Error>(this.reader.getUint32());
+        return Result.ok<u32>(this.reader.getUint32());
     }
-    return Result.err<u32, Error>(new RangeError(E_INVALIDLENGTH));
+    return Result.err<u32>(new RangeError(E_INVALIDLENGTH));
   }
 
-  readByteArray(): Result<ArrayBuffer, Error> {
+  readByteArray(): Result<ArrayBuffer> {
     const result = this.readBinLength();
     if (result.isErr) {
-      return Result.err<ArrayBuffer, Error>(result.unwrapErr());
+      return Result.err<ArrayBuffer>(result.unwrapErr());
     }
 
     const arrLength = result.unwrap();
     const arrBytes = this.reader.getBytes(arrLength);
-    return Result.ok<ArrayBuffer, Error>(arrBytes);
+    return Result.ok<ArrayBuffer>(arrBytes);
   }
 
-  readArraySize(): Result<u32, Error> {
+  readArraySize(): Result<u32> {
     const leadByte = this.reader.getUint8();
     if (this.isFixedArray(leadByte)) {
-      return Result.ok<u32, Error>(<u32>(leadByte & Format.FOUR_LEAST_SIG_BITS_IN_BYTE));
+      return Result.ok<u32>(<u32>(leadByte & Format.FOUR_LEAST_SIG_BITS_IN_BYTE));
     } else if (leadByte == Format.ARRAY16) {
-      return Result.ok<u32, Error>(<u32>this.reader.getUint16());
+      return Result.ok<u32>(<u32>this.reader.getUint16());
     } else if (leadByte == Format.ARRAY32) {
-      return Result.ok<u32, Error>(this.reader.getUint32());
+      return Result.ok<u32>(this.reader.getUint32());
     } else if (leadByte == Format.NIL) {
-      return Result.ok<u32, Error>(0);
+      return Result.ok<u32>(0);
     }
-    return Result.err<u32, Error>(new RangeError(E_INVALIDLENGTH + leadByte.toString()));
+    return Result.err<u32>(new RangeError(E_INVALIDLENGTH + leadByte.toString()));
   }
 
-  readMapSize(): Result<u32, Error> {
+  readMapSize(): Result<u32> {
     const leadByte = this.reader.getUint8();
     if (this.isFixedMap(leadByte)) {
-      return Result.ok<u32, Error>(<u32>(leadByte & Format.FOUR_LEAST_SIG_BITS_IN_BYTE));
+      return Result.ok<u32>(<u32>(leadByte & Format.FOUR_LEAST_SIG_BITS_IN_BYTE));
     } else if (leadByte == Format.MAP16) {
-      return Result.ok<u32, Error>(<u32>this.reader.getUint16());
+      return Result.ok<u32>(<u32>this.reader.getUint16());
     } else if (leadByte == Format.MAP32) {
-      return Result.ok<u32, Error>(this.reader.getUint32());
+      return Result.ok<u32>(this.reader.getUint32());
     }
-    return Result.err<u32, Error>(new RangeError(E_INVALIDLENGTH));
+    return Result.err<u32>(new RangeError(E_INVALIDLENGTH));
   }
 
   private isFloat32(u: u8): bool {
@@ -580,10 +580,10 @@ export class SafeDecoder {
     return objectsToDiscard;
   }
 
-  readArray<T>(fn: (decoder: SafeDecoder) => Result<T, Error>): Result<Array<T>, Error> {
+  readArray<T>(fn: (decoder: SafeDecoder) => Result<T>): Result<Array<T>> {
     const result = this.readArraySize();
     if (result.isErr) {
-      return Result.err<Array<T>, Error>(result.unwrapErr());
+      return Result.err<Array<T>>(result.unwrapErr());
     }
 
     const size = result.unwrap();
@@ -592,56 +592,54 @@ export class SafeDecoder {
       const item = fn(this).unwrap();
       a.push(item);
     }
-    return Result.ok<Array<T>, Error>(a);
+    return Result.ok<Array<T>>(a);
   }
 
-  readNullableArray<T>(fn: (decoder: SafeDecoder) => Result<T, Error>): Result<Array<T> | null, Error> {
+  readNullableArray<T>(fn: (decoder: SafeDecoder) => Result<T>): Result<Array<T> | null> {
     if (this.isNextNil()) {
-      return Result.ok<Array<T> | null, Error>(null);
+      return Result.ok<Array<T> | null>(null);
     }
 
     const result = this.readArray(fn);
     if (result.isOk) {
-      return Result.ok<Array<T> | null, Error>(result.unwrap());
+      return Result.ok<Array<T> | null>(result.unwrap());
     } else {
-      return Result.err<Array<T> | null, Error>(result.unwrapErr());
+      return Result.err<Array<T> | null>(result.unwrapErr());
     }
-    // return this.readArray(fn).map<Array<T> | null>((v) => { return v; });
   }
 
   readMap<K, V>(
-    keyFn: (decoder: SafeDecoder) => Result<K, Error>,
-    valueFn: (decoder: SafeDecoder) => Result<V, Error>
-  ): Result<Map<K, V>, Error> {
+    keyFn: (decoder: SafeDecoder) => Result<K>,
+    valueFn: (decoder: SafeDecoder) => Result<V>
+  ): Result<Map<K, V>> {
     const result = this.readMapSize();
     if (result.isErr) {
-      return Result.err<Map<K, V>, Error>(result.unwrapErr());
+      return Result.err<Map<K, V>>(result.unwrapErr());
     }
 
     const size = result.unwrap();
     let m = new Map<K, V>();
     for (let i: u32 = 0; i < size; i++) {
-      const key = keyFn(this).unwrap();
-      const value = valueFn(this).unwrap();
+      const key = keyFn(this).unwrap(); // todo
+      const value = valueFn(this).unwrap(); // todo
       m.set(key, value);
     }
-    return Result.ok<Map<K, V>, Error>(m);
+    return Result.ok<Map<K, V>>(m);
   }
 
   readNullableMap<K, V>(
-    keyFn: (decoder: SafeDecoder) => Result<K, Error>,
-    valueFn: (decoder: SafeDecoder) => Result<V, Error>
-  ): Result<Map<K, V> | null, Error> {
+    keyFn: (decoder: SafeDecoder) => Result<K>,
+    valueFn: (decoder: SafeDecoder) => Result<V>
+  ): Result<Map<K, V> | null> {
     if (this.isNextNil()) {
-      return Result.ok<Map<K, V> | null, Error>(null);
+      return Result.ok<Map<K, V> | null>(null);
     }
 
     const result = this.readMap(keyFn, valueFn);
     if (result.isOk) {
-      return Result.ok<Map<K, V> | null, Error>(result.unwrap());
+      return Result.ok<Map<K, V> | null>(result.unwrap());
     } else {
-      return Result.err<Map<K, V> | null, Error>(result.unwrapErr());
+      return Result.err<Map<K, V> | null>(result.unwrapErr());
     }
-    // return this.readMap(keyFn, valueFn).map<Map<K, V> | null>((v) => { return v; });
   }
 }

--- a/assembly/result.ts
+++ b/assembly/result.ts
@@ -1,0 +1,61 @@
+export class Result<T, E> {
+  public readonly isOk: boolean;
+  private readonly ok: T;
+  private readonly err: E;
+
+  static ok<T, E>(t: T): Result<T, E> {
+    return new Result<T, E>(true, t, dummy<E>());
+  }
+
+  static err<T, E>(err: E): Result<T, E> {
+    return new Result<T, E>(false, dummy<T>(), err);
+  }
+
+  protected constructor(isOk: boolean, ok: T, err: E) {
+    this.isOk = isOk;
+    this.ok = ok;
+    this.err = err;
+  }
+
+  map<U>(fn: (t: T) => U): Result<U, E> {
+    if (this.isOk) {
+      return Result.ok<U, E>(fn(this.ok));
+    }
+    return Result.err<U, E>(this.err);
+  }
+
+  unwrap(): T {
+    if (this.isOk) {
+      return this.ok;
+    }
+    throw new Error("called unwrap on Err(E)");
+  }
+
+  unwrap_err(): E {
+    if (!this.isOk) {
+      return this.err;
+    }
+    throw new Error("called unwrap_err on Ok(T)");
+  }
+
+  unwrap_or(t: T): T {
+    if (this.isOk) {
+      return this.ok;
+    } else {
+      return t;
+    }
+  }
+
+  get isErr(): boolean { return !this.isOk }
+}
+
+function dummy<T>(): T {
+  if (isInteger<T>()) {
+    return <T>0;
+  } else if (isFloat<T>()) {
+    return <T>0.0;
+  } else {
+    assert(isReference<T>())
+    return changetype<T>(0);
+  }
+}

--- a/assembly/result.ts
+++ b/assembly/result.ts
@@ -31,13 +31,6 @@ export class Result<T> {
     return this.err;
   }
 
-  unwrapOr(t: T): T {
-    if (this.isOk) {
-      return this.ok;
-    }
-    return t;
-  }
-
   get isErr(): boolean { return !this.isOk }
 }
 

--- a/assembly/result.ts
+++ b/assembly/result.ts
@@ -1,17 +1,17 @@
-export class Result<T, E> {
+export class Result<T> {
   public readonly isOk: boolean;
   private readonly ok: T;
-  private readonly err: E;
+  private readonly err: Error;
 
-  static ok<T, E>(t: T): Result<T, E> {
-    return new Result<T, E>(true, t, dummy<E>());
+  static ok<T>(t: T): Result<T> {
+    return new Result<T>(true, t, dummy<Error>());
   }
 
-  static err<T, E>(err: E): Result<T, E> {
-    return new Result<T, E>(false, dummy<T>(), err);
+  static err<T>(err: Error): Result<T> {
+    return new Result<T>(false, dummy<T>(), err);
   }
 
-  protected constructor(isOk: boolean, ok: T, err: E) {
+  protected constructor(isOk: boolean, ok: T, err: Error) {
     this.isOk = isOk;
     this.ok = ok;
     this.err = err;
@@ -21,10 +21,10 @@ export class Result<T, E> {
     if (this.isOk) {
       return this.ok;
     }
-    throw new Error("called unwrap on Err(E)");
+    throw this.err;
   }
 
-  unwrapErr(): E {
+  unwrapErr(): Error {
     if (this.isOk) {
       throw new Error("called unwrapErr on Ok(T)");
     }

--- a/assembly/result.ts
+++ b/assembly/result.ts
@@ -17,13 +17,6 @@ export class Result<T, E> {
     this.err = err;
   }
 
-  map<U>(fn: (t: T) => U): Result<U, E> {
-    if (this.isOk) {
-      return Result.ok<U, E>(fn(this.ok));
-    }
-    return Result.err<U, E>(this.err);
-  }
-
   unwrap(): T {
     if (this.isOk) {
       return this.ok;
@@ -31,19 +24,18 @@ export class Result<T, E> {
     throw new Error("called unwrap on Err(E)");
   }
 
-  unwrap_err(): E {
-    if (!this.isOk) {
-      return this.err;
+  unwrapErr(): E {
+    if (this.isOk) {
+      throw new Error("called unwrapErr on Ok(T)");
     }
-    throw new Error("called unwrap_err on Ok(T)");
+    return this.err;
   }
 
-  unwrap_or(t: T): T {
+  unwrapOr(t: T): T {
     if (this.isOk) {
       return this.ok;
-    } else {
-      return t;
     }
+    return t;
   }
 
   get isErr(): boolean { return !this.isOk }

--- a/assembly/result.ts
+++ b/assembly/result.ts
@@ -4,11 +4,11 @@ export class Result<T> {
   private readonly err: Error;
 
   static ok<T>(t: T): Result<T> {
-    return new Result<T>(true, t, dummy<Error>());
+    return new Result<T>(true, t, phantomType<Error>());
   }
 
   static err<T>(err: Error): Result<T> {
-    return new Result<T>(false, dummy<T>(), err);
+    return new Result<T>(false, phantomType<T>(), err);
   }
 
   protected constructor(isOk: boolean, ok: T, err: Error) {
@@ -41,7 +41,7 @@ export class Result<T> {
   get isErr(): boolean { return !this.isOk }
 }
 
-function dummy<T>(): T {
+function phantomType<T>(): T {
   if (isInteger<T>()) {
     return <T>0;
   } else if (isFloat<T>()) {

--- a/assembly/sizer.ts
+++ b/assembly/sizer.ts
@@ -123,7 +123,7 @@ export class Sizer implements Writer {
     this.length += 9;
   }
 
-  writeArray<T>(a: Array<T>, fn: (sizer: Sizer, item: T) => void): void {
+  writeArray<T>(a: Array<T>, fn: (sizer: Writer, item: T) => void): void {
     this.writeArraySize(a.length);
     for (let i: i32 = 0; i < a.length; i++) {
       fn(this, a[i]);


### PR DESCRIPTION
This is a workaround for the lack of support of exceptions in Assemblyscript. I'm adding a SafeDecoder that returns a Result<T, Error> instead of throwing errors. This is especially useful to us to build hierarchical error (e.g. `key foo doesn't exist in toto.bar`) within deeply nested structures.

I've made sure to preserve compatibility with the previous API by exposing a Decoder that internally uses the SafeDecoder, but unwrap every errors.

I've also added a few missing test cases and fixed a bug revealed by the added tests for `Sizer.writeArray`.

Let me know what you think!
